### PR TITLE
Support for Arduino Giga and MCUFRIEND displays.

### DIFF
--- a/font_test/board_select.h
+++ b/font_test/board_select.h
@@ -97,3 +97,45 @@
     display.setBacklight(255);
   };
 #endif
+
+#ifdef USE_GIGA_GFX
+  /*
+   * Definitions for the Arduino Giga R1 and its conmpanion Giga Display.
+   */
+
+  #include "Arduino_GigaDisplay_GFX.h"
+
+  GigaDisplay_GFX display;
+  #define DWIDTH 800
+  #define DHEIGHT 480
+  #define COLOR_BLACK  0
+  #define COLOR_YELLOW display.color565(0xFF, 0xFF, 0)
+  #define COLOR_WHITE  0xFFFF
+  void Initialize_Display(void){ 
+    display.begin();
+    display.setRotation(1);
+  };
+#endif
+
+#ifdef USE_MCUFRIEND
+  /*
+   * Definitions for the 2.8 inch MCUFRIEND displays.
+   */
+
+  #include <Adafruit_GFX.h>
+  #include <MCUFRIEND_kbv.h>
+  MCUFRIEND_kbv display;
+
+  #define DWIDTH 320
+  #define DHEIGHT 240
+  #define COLOR_BLACK  0
+  #define COLOR_YELLOW 0xFFE0
+  #define COLOR_WHITE  0xFFFF
+  void Initialize_Display(void){ 
+    uint16_t ID = display.readID();
+    Serial.print("TFT ID = 0x");
+    Serial.println(ID, HEX);
+    display.begin(ID);
+    display.setRotation(1);
+  };
+#endif

--- a/font_test/font_test.ino
+++ b/font_test/font_test.ino
@@ -10,6 +10,8 @@
 //#define USE_HX8357    //3.5 inch 480x320 TFT Feather Wing
 //#define USE_HALLOWING //Adafruit Hallowing M0 Express
 //#define USE_PYGAMER   //Adafruit PyGamer M4 Express
+//#define USE_GIGA_GFX    //Arduino Giga R1 with display
+//#define USE_MCUFRIEND     // 2.8 inch 240x320 MCUFRIEND displays
 #include "board_select.h"
 
 /*
@@ -61,7 +63,7 @@ void Show(void)  {
   #define BASE_R 22
   uint8_t Max_C = DWIDTH / (DELTA_C * Magnifier);
   uint8_t Max_R = DHEIGHT / (DELTA_R * Magnifier);
-  uint8_t NumChar = Max_C * Max_R;
+  uint16_t NumChar = Max_C * Max_R;
   uint16_t Last_Glyph = min(First_Glyph+NumChar-1,SymbolMono18pt7b.last+128-32);
   Serial.print("Displaying "); Serial.print(NumChar,DEC);
   Serial.print(" glyphs in "); Serial.print(Max_R,DEC);


### PR DESCRIPTION
Add support for the Arduino Giga display, and for common (e.g. 2.8 inch) MCUFRIEND displays. 
Fix overflow in rows * cols calculation when displaying on high resolution displays (such as the Giga)